### PR TITLE
HMS-6 Implement GitHub Action to enforce Jira-keyed commit messages

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -1,0 +1,24 @@
+name: "Commit Message Check"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  message-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Commit Messages
+        run: |
+          commits=$(git log --pretty=format:"%s" ${{ github.event.before }}..${{ github.sha }})
+          for commit in $commits
+          do
+            if [[ ! $commit =~ ^[A-Z]+-[0-9]+.*$ ]]; then
+              echo "error: invalid commit message - $commit"
+              echo "Commit messages must start with a JIRA key (e.g., ABC-123)"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
# Summary
* Implement a GitHub Action that checks the format of commit messages on every push and pull request to the main branch.