### PR TITLE
HMS-8 add cucumber dependencies

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.cucumber:cucumber-java:7.14.0'
+	testImplementation 'io.cucumber:cucumber-junit:7.14.0'
+	testImplementation 'io.cucumber:cucumber-junit-platform-engine:7.14.0'
+	testImplementation 'io.cucumber:cucumber-spring:7.14.0'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
# Summary 
* Cdded necessary cucumber dependencies do build.gradle (I believe we won't be writing cucumber test for the first deliverable)

# Note
* For those who use Intellij, please install the Gherkin plugin which adds support for the Gherkin language (features), which is used by the Cucumber testing tool. 